### PR TITLE
fix: github-pr crashes when the pr includes a license issue

### DIFF
--- a/lib/patches.js
+++ b/lib/patches.js
@@ -8,6 +8,7 @@ const sort = require('./utils/sort');
 const semver = require('semver');
 const moduleToObject = require('snyk-module');
 const cloneDeep = require('lodash.clonedeep');
+const _get = require('lodash.get');
 
 function patches(vulns) {
   if (!vulns || vulns.length === 0) {
@@ -43,7 +44,7 @@ function patches(vulns) {
       } else {
         // try to find the right vuln id based on the publication times
         last = (all.filter(vuln => {
-          var patch = vuln.patches[0];
+          var patch = _get(vuln, 'patches[0]');
 
           // don't select the one we're looking at
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "debug": "^2.2.0",
     "es6-promise": "^3.2.1",
     "lodash.clonedeep": "^4.3.2",
+    "lodash.get": "^4.4.2",
     "semver": "^5.1.0",
     "snyk-module": "^1.7.0"
   },


### PR DESCRIPTION
this problem: https://app.logz.io/kibana-app/kibana#/doc/[logz-xyysvteyvqkprdiuofahailqufuezrqh-]YYMMDD/logz-xyysvteyvqkprdiuofahailqufuezrqh-170703_v6/prod/?id=AV0IyNSgv03XqAyWgfnR

caused the github-pr to fail: https://app.logz.io/kibana-app/kibana#/doc/[logz-xyysvteyvqkprdiuofahailqufuezrqh-]YYMMDD/logz-xyysvteyvqkprdiuofahailqufuezrqh-170703_v6/prod/?id=AV0IyNhxv03XqAyWgmIR

The reason is that license issues have no `patch` field, but node-remediation does not know this and assumes it exists, so crashes.