### PR TITLE
fix: roll back some dependencies for Node 0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "Apache 2.0",
   "dependencies": {
     "babel-runtime": "^6.9.2",
-    "debug": "^3.0.0",
+    "debug": "^2.2.0",
     "es6-promise": "^3.2.1",
     "lodash.clonedeep": "^4.3.2",
     "lodash.get": "^4.4.2",
@@ -42,7 +42,7 @@
     "proxyquire": "^1.7.9",
     "semantic-release": "^4.3.5",
     "sinon": "^1.17.4",
-    "tap": "^10.0.0"
+    "tap": "^5.7.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Node 0.10 explodes because some transitives have become incompatible with Node 0.10